### PR TITLE
Added support for development SMTP servers like MailHog

### DIFF
--- a/examples/developmentMode.js
+++ b/examples/developmentMode.js
@@ -1,0 +1,13 @@
+var sendmail = require('../sendmail')({silent: true, devPort: 1025});
+
+sendmail({
+    from: 'test@yourdomain.com',
+    to: 'info@yourdomain.com',
+    replyTo: 'jason@yourdomain.com',
+    subject: 'MailComposer sendmail',
+    html: 'Mail of test sendmail'
+  }, function(err, reply) {
+    console.log(err && err.stack);
+    console.dir(reply);
+});
+

--- a/sendmail.js
+++ b/sendmail.js
@@ -16,6 +16,7 @@ var exports = module.exports = function(options) {
     warn: console.warn,
     error: console.error
   })
+  var devPort = options.devPort || -1;
 
   /*
    *   邮件服务返回代码含义 Mail service return code Meaning
@@ -63,37 +64,51 @@ var exports = module.exports = function(options) {
    * connect to domain by Mx record
    */
   function connectMx(domain, callback) {
-    dns.resolveMx(domain, function(err, data) {
-        if (err)
-          return callback(err);
+      if (devPort === -1) { // not in development mode -> search the MX
+        dns.resolveMx(domain, function(err, data) {
+            if (err)
+              return callback(err);
 
-        data.sort(function(a, b) {return a.priority < b. priority});
-        logger.debug('mx resolved: ', data);
+            data.sort(function(a, b) {return a.priority < b. priority});
+            logger.debug('mx resolved: ', data);
 
-        if (!data || data.length == 0)
-          return callback(new Error('can not resolve Mx of <' + domain + '>'));
+            if (!data || data.length == 0)
+              return callback(new Error('can not resolve Mx of <' + domain + '>'));
 
-        function tryConnect(i) {
+            function tryConnect(i) {
 
-          if (i >= data.length) return callback(new Error('can not connect to any SMTP server'));
+              if (i >= data.length) return callback(new Error('can not connect to any SMTP server'));
 
-          var sock = tcp.createConnection(25, data[i].exchange);
+              var sock = tcp.createConnection(25, data[i].exchange);
+
+              sock.on('error', function(err) {
+                  logger.error('Error on connectMx for: ', data[i], err);
+                  tryConnect(++i);
+              });
+
+              sock.on('connect', function() {
+                  logger.debug("MX connection created: ", data[i].exchange);
+                  sock.removeAllListeners('error');
+                  callback(null, sock);
+              });
+
+            };
+
+            tryConnect(0);
+        });
+      } else { // development mode -> connect to the specified devPort on localhost
+          var sock = tcp.createConnection(devPort);
 
           sock.on('error', function(err) {
-              logger.error('Error on connectMx for: ', data[i], err);
-              tryConnect(++i);
+              callback(new Error('Error on connectMx (development) for \"localhost:' + devPort + '\": '+ err));
           });
 
           sock.on('connect', function() {
-              logger.debug("MX connection created: ", data[i].exchange);
+              logger.debug("MX (development) connection created: localhost:"+devPort);
               sock.removeAllListeners('error');
               callback(null, sock);
           });
-
-        };
-
-        tryConnect(0);
-    });
+      }
   }
 
   function sendToSMTP(domain, srcHost, from, recipients, body, cb) {


### PR DESCRIPTION
## Description
A property describing a port for a local SMTP server (see [MailHog](https://github.com/mailhog/MailHog)) was added. If the property is omitted, sendmail behaves like it used to.

## Motivation and Context
This feature makes it possible to test an application offline and for multiple email addresses without needing to create hundreds of mail accounts.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
