### PR TITLE
Add DKIM signing

### DIFF
--- a/examples/dkim.js
+++ b/examples/dkim.js
@@ -1,0 +1,19 @@
+var fs = require('fs');
+var sendmail = require('../sendmail')({
+  silent:true,
+  dkim: {
+    privateKey: fs.readFileSync('dkim-private.pem', 'utf-8'),
+    keySelector: 'mydomainkey'
+  }
+});
+
+sendmail({
+    from: 'test@yourdomain.com',
+    to: 'info@yourdomain.com',
+    replyTo: 'jason@yourdomain.com',
+    subject: 'MailComposer sendmail',
+    html: 'Mail of test sendmail ',
+  }, function(err, reply) {
+    console.log(err && err.stack);
+    console.dir(reply);
+});

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "node": ">=0.6.0"
   },
   "dependencies": {
+    "dkim-signer": "^0.2.2",
     "mailcomposer": "^3.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I added a `dkim` object to options that can have two properties: `privateKey` and `keySelector`.
These options correspond to the options for [`dkim-signer`](https://github.com/andris9/dkim-signer).

Tested with a DKIM key from my own domain using http://dkimvalidator.com/

Also added an example for these options.