### PR TITLE
added devHost option

### DIFF
--- a/sendmail.js
+++ b/sendmail.js
@@ -20,6 +20,7 @@ module.exports = function (options) {
   const dkimPrivateKey = (options.dkim || {}).privateKey;
   const dkimKeySelector = (options.dkim || {}).keySelector || 'dkim';
   const devPort = options.devPort || -1;
+  const devHost = options.devHost || 'localhost';
 
   /*
    *   邮件服务返回代码含义 Mail service return code Meaning
@@ -101,15 +102,15 @@ module.exports = function (options) {
 
         tryConnect(0)
       })
-    } else { // development mode -> connect to the specified devPort on localhost
-      const sock = createConnection(devPort);
+    } else { // development mode -> connect to the specified devPort on devHost
+      const sock = createConnection(devPort, devHost);
 
       sock.on('error', function (err) {
-        callback(new Error('Error on connectMx (development) for "localhost:' + devPort + '": ' + err))
+        callback(new Error('Error on connectMx (development) for "'+ devHost +':' + devPort + '": ' + err))
       });
 
       sock.on('connect', function () {
-        logger.debug('MX (development) connection created: localhost:' + devPort);
+        logger.debug('MX (development) connection created: '+ devHost +':' + devPort);
         sock.removeAllListeners('error');
         callback(null, sock)
       })


### PR DESCRIPTION
## Description
Add option to override "localhost" when sending all SMTP traffic to a dummy server. 

## Motivation and Context
It's a simple addition and makes the testing behavior a little more flexible.

Actually though I already have an SMTP server and adding this was a cheap way to direct my email through that server.

## How Has This Been Tested?
Works for me.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
