### PR TITLE
sort mx records by priority (lowest first)

### DIFF
--- a/sendmail.js
+++ b/sendmail.js
@@ -77,7 +77,7 @@ module.exports = function (options) {
           return callback(err)
         }
 
-        data.sort(function (a, b) { return a.priority < b.priority });
+        data.sort(function (a, b) { return a.priority > b.priority });
         logger.debug('mx resolved: ', data);
 
         if (!data || data.length === 0) {


### PR DESCRIPTION
Taken from https://en.wikipedia.org/wiki/MX_record#Priority

> Mail is delivered to the mail exchange server with the lowest preference number (highest priority), so the MX record you use for mail routing should have the lowest preference number, typically 0. 

## Description
Currently the mail is sent by using the MX record with the highest priority. This PR changes it to use the record with the lowest priority first.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
