### PR TITLE
Remove autoparse

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "auto-parse": "^1.7.0",
     "dkim-signer": "^0.2.2",
     "mailcomposer": "^3.12.0"
   },

--- a/sendmail.js
+++ b/sendmail.js
@@ -1,7 +1,6 @@
 const {createConnection} = require('net');
 const {resolveMx} = require('dns');
 const {DKIMSign} = require('dkim-signer');
-const autoParse = require('auto-parse');
 const CRLF = '\r\n';
 
 function dummy () {}
@@ -231,7 +230,7 @@ module.exports = function (options) {
         if (line[3] === ' ') {
             // 250-information dash is not complete.
             // 250 OK. space is complete.
-          let lineNumber = autoParse(line, Number)
+          let lineNumber = parseInt(line.substr(0, 3))
           response(lineNumber, msg);
           msg = '';
         }


### PR DESCRIPTION
auto-parse doesn't work. `autoParse('123 Words') === NaN`. `autoParse('123 Words'.substr(0, 3))` would work, but I don't think autoParse is necessary at all. It adds unneeded complexity to a simple task, and if you step through the code, it boils down to `new Number(string)` anyways. No need for the extra library.

I did not update the version. I believe this can easily be rolled into your next release.

## Description
Replaces usage of `autoParse` with `parseInt`, and focuses on the first three characters of the line. The use of the magic number 3 is in keeping with `line[3] === ' '` from a previous line. 🦎 Chameleon coding.

## Motivation and Context
I was not able to send myself an email using simple examples.

## How Has This Been Tested?
I modified the code, in situ, and I was able to send myself an email.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
