### PR TITLE
Prevent multiple calls to callback

### DIFF
--- a/sendmail.js
+++ b/sendmail.js
@@ -383,9 +383,25 @@ module.exports = function (options) {
         });
         message = signature + '\r\n' + message;
       }
-      for (let domain in groups) {
-        sendToSMTP(domain, srcHost, from, groups[domain], message, callback);
+      
+      const domains = Object.keys(groups);
+      function processDomain() {
+        const domain = domains.shift();
+        if (!domain) {
+          callback();
+          return;
+        }
+
+        sendToSMTP(domain, srcHost, from, groups[domain], message, (err, msg) => {
+          if (err) {
+            callback(err);
+          } else {
+            processDomain();
+          }
+        })
       }
+      
+      processDomain();
     });
   }
   return sendmail;


### PR DESCRIPTION
## Description
Ensure that callback is called only once at the end

## Motivation and Context
When emails are from different domains, ensure that callback is called after all of the emails are sent

## How Has This Been Tested?
Just try send email to two different domains (Expected - callback is called when all emails are sent)

## Types of changes
Bug fix (Do not return response from sending - is it really necessary ?)

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
